### PR TITLE
Fix VISUAL variable typo

### DIFF
--- a/home/ryan/shell/default.nix
+++ b/home/ryan/shell/default.nix
@@ -48,7 +48,7 @@
     ];
     sessionVariables = {
       EDITOR = lib.mkForce "vim";
-      VISIAL = "vim";
+      VISUAL = "vim";
       PAGER = "less";
       LESS = "-R";
       BROWSER = "firefox";


### PR DESCRIPTION
## Summary
- correct VISUAL typo in Ryan's shell config

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake check` *(fails: expected set but found a function)*

------
https://chatgpt.com/codex/tasks/task_e_685cb625d5a4833288976f969431152a