### PR TITLE
Re-enable Feishin

### DIFF
--- a/home/ryan/entertainment.nix
+++ b/home/ryan/entertainment.nix
@@ -3,7 +3,7 @@
   home.packages = with pkgs; [
     jellyfin-media-player
     jellycli
-    # feishin TODO: BROKEN 
+    feishin
     spotube
     youtube-music
     vlc


### PR DESCRIPTION
## Summary
- enable Feishin in Ryan's entertainment package list

## Testing
- `nix flake check --no-build --print-build-logs` *(fails: expected a set but found a function)*

------
https://chatgpt.com/codex/tasks/task_e_685cb64ae3188332956cb02c6fe75f10