### PR TITLE
Fix newline in CI config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,3 +13,4 @@ update-flake:
     - git push origin HEAD:$CI_COMMIT_REF_NAME
   only:
     - schedules
+


### PR DESCRIPTION
## Summary
- ensure `.gitlab-ci.yml` ends with a newline

## Testing
- `ruby -ryaml -e 'YAML.load_file(".gitlab-ci.yml"); puts "valid"'`


------
https://chatgpt.com/codex/tasks/task_e_685cb65c89e8833285d01db9ae7cc98f