### PR TITLE
Add flake checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,13 @@
+name: Nix checks
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v22
+      - run: nix flake check

--- a/flake.nix
+++ b/flake.nix
@@ -164,6 +164,33 @@
       # Other options beside 'alejandra' include 'nixpkgs-fmt'
       formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
 
+      checks = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          format = pkgs.runCommand "nixpkgs-fmt-check" {
+            nativeBuildInputs = [ pkgs.nixpkgs-fmt pkgs.findutils ];
+          } ''
+            find ${self} -name '*.nix' -print0 | xargs -0 nixpkgs-fmt --check
+            touch $out
+          '';
+
+          deadnix = pkgs.runCommand "deadnix-check" {
+            nativeBuildInputs = [ pkgs.deadnix pkgs.findutils ];
+          } ''
+            find ${self} -name '*.nix' -print0 | xargs -0 deadnix
+            touch $out
+          '';
+
+          statix = pkgs.runCommand "statix-check" {
+            nativeBuildInputs = [ pkgs.statix ];
+          } ''
+            statix check ${self}
+            touch $out
+          '';
+        });
+
       # Your custom packages and modifications, exported as overlays
       overlays = import ./overlays { inherit inputs; };
 


### PR DESCRIPTION
## Summary
- define a `checks` output in `flake.nix` that runs `nixpkgs-fmt`, `deadnix` and `statix`
- add a GitHub Actions workflow to run `nix flake check`

## Testing
- `nix flake check` *(fails: expected a set but found a function)*

------
https://chatgpt.com/codex/tasks/task_e_685d02fbb1bc8332b2991323746873b8